### PR TITLE
GetAll Fix

### DIFF
--- a/src/progress/infraestructure/repositories/odm-repositories/odm-progress-repository.ts
+++ b/src/progress/infraestructure/repositories/odm-repositories/odm-progress-repository.ts
@@ -84,7 +84,7 @@ export class OdmProgressRepository implements ProgressQueryRepository {
         {
             const {page, perPage} = pagination;
             const startedCourses = await this.progressModel.find( {'user_id': userId} ).skip((page-1)*perPage).limit(perPage).sort( {'last_seen_date':'desc'} );
-            if ( (startedCourses == null)||(startedCourses.length === 0) )
+            if ( startedCourses == null )
             {
                 return Result.fail<OdmProgressEntity[]>(new Error("No progress found for the given user"), 404, "No progress found for the given user");
             }

--- a/src/progress/infraestructure/repositories/orm-repositories/orm-progress-course-repository.ts
+++ b/src/progress/infraestructure/repositories/orm-repositories/orm-progress-course-repository.ts
@@ -247,7 +247,7 @@ export class OrmProgressCourseRepository extends Repository<OrmProgressCourse> i
                 }
                 return Result.success<CourseSubscription[]>( domainCourses, 200 );
             }
-            return Result.fail<CourseSubscription[]>(new Error("No started courses found"), 404, "No started courses found");
+            return Result.success<CourseSubscription[]>( [],200 );
         }
         catch (error)
         {
@@ -300,7 +300,7 @@ export class OrmProgressCourseRepository extends Repository<OrmProgressCourse> i
             {
                 return Result.success<SectionProgress[]>( progressArray, 200 );
             }
-            return Result.fail<SectionProgress[]>(new Error("No started sections found on course"), 404, "No started sections found on course");
+            return Result.success<SectionProgress[]>( [],200 );
         }
         catch (error)
         {

--- a/src/trainer/infraestructure/repositories/odm-repositories/odm-trainer-repository.ts
+++ b/src/trainer/infraestructure/repositories/odm-repositories/odm-trainer-repository.ts
@@ -82,7 +82,7 @@ export class OdmTrainerRepository implements TrainerQueryRepository {
             const odmTrainers = await this.trainerModel.find( {latitude: latitude, longitude: longitude} ).skip( (pagination.page-1)*pagination.perPage ).limit( pagination.perPage );
             if (odmTrainers.length == 0)
             {
-                return Result.fail<OdmTrainerEntity[]>( new Error("Trainers not found"), 404, "Trainers not found");
+                return Result.success<OdmTrainerEntity[]>( [], 200 );
             }
             return Result.success<OdmTrainerEntity[]>( odmTrainers, 200 );
         } catch (error)
@@ -96,7 +96,7 @@ export class OdmTrainerRepository implements TrainerQueryRepository {
             const odmTrainers = await this.trainerModel.find( {"followers.id": followerID} ).skip( (pagination.page-1)*pagination.perPage ).limit( pagination.perPage );
             if (odmTrainers.length == 0)
             {
-                return Result.fail<OdmTrainerEntity[]>( new Error("Trainers not found"), 404, "Trainers not found");
+                return Result.success<OdmTrainerEntity[]>( [], 200 );
             }
             return Result.success<OdmTrainerEntity[]>( odmTrainers, 200 );
         } catch (error)
@@ -110,7 +110,7 @@ export class OdmTrainerRepository implements TrainerQueryRepository {
             const odmTrainers = await this.trainerModel.find().skip( (pagination.page-1)*pagination.perPage ).limit( pagination.perPage );
             if (odmTrainers.length == 0)
             {
-                return Result.fail<OdmTrainerEntity[]>( new Error("Trainers not found"), 404, "Trainers not found");
+                return Result.success<OdmTrainerEntity[]>( [], 200 );
             }
             return Result.success<OdmTrainerEntity[]>( odmTrainers, 200 );
         } catch (error)

--- a/src/trainer/infraestructure/repositories/orm-repositories/orm-trainer-repository.ts
+++ b/src/trainer/infraestructure/repositories/orm-repositories/orm-trainer-repository.ts
@@ -46,7 +46,7 @@ export class OrmTrainerRepository extends Repository<OrmTrainer> implements ITra
             {
                 return Result.success<Trainer[]>( await Promise.all( trainers.map( async trainer => await this.ormTrainerMapper.fromPersistenceToDomain( trainer ) ) ), 200 )
             }
-            return Result.fail<Trainer[]>( new Error("Trainers not found"), 404, "Trainers not found");
+            return Result.success<Trainer[]>( [], 200 );
         }
         catch (error)
         {
@@ -69,7 +69,7 @@ export class OrmTrainerRepository extends Repository<OrmTrainer> implements ITra
             {
                 return Result.success<Trainer[]>( await Promise.all( trainers.map( async trainer => await this.ormTrainerMapper.fromPersistenceToDomain( trainer ) ) ), 200 )
             }
-            return Result.fail<Trainer[]>( new Error("Trainers not found"), 404, "Trainers not found");
+            return Result.success<Trainer[]>( [], 200 );
         }
         catch (error)
         {
@@ -129,7 +129,7 @@ export class OrmTrainerRepository extends Repository<OrmTrainer> implements ITra
             {
                 return Result.success<string[]>( followersID, 200 )
             }
-            return Result.fail<string[]>( new Error("Followers not found"), 404, "Followers not found");
+            return Result.success<string[]>( [], 200 );
         }
         catch (error)
         {


### PR DESCRIPTION
Fixes behaviour of GetAll endpoints for Trainer, Progress on case of not finding any entities Instead of sending 404 error, sends empty array